### PR TITLE
Adding noreplace to /etc/init.d/jenkins

### DIFF
--- a/suse/build/SPECS/jenkins.spec
+++ b/suse/build/SPECS/jenkins.spec
@@ -119,7 +119,7 @@ exit 0
 %attr(0750,%{name},%{name}) /var/log/%{name}
 %attr(0750,%{name},%{name}) /var/cache/%{name}
 %config(noreplace) /etc/logrotate.d/%{name}
-%config /etc/init.d/%{name}
+%config(noreplace) /etc/init.d/%{name}
 %config(noreplace) /etc/sysconfig/%{name}
 %config(noreplace) /etc/zypp/repos.d/%{name}.repo
 /usr/sbin/rc%{name}


### PR DESCRIPTION
If you have adapted `/etc/init.d/jenkins` for your purposes, you don't want the file being overridden from an update.
